### PR TITLE
Update GitHub workflows configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         features:
-          - color
-          - hello
+          - cmake
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -34,8 +33,7 @@ jobs:
     strategy:
       matrix:
         features:
-          - color
-          - hello
+          - cmake
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR updates the GitHub workflow configurations for this repo by removing the `color` and `hello` example features and replacing them with the `cmake` feature.

Closes #3 