### PR TITLE
Update CMake feature to work with arm

### DIFF
--- a/src/cmake/devcontainer-feature.json
+++ b/src/cmake/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "cmake",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "CMake",
   "description": "Install an up-to-date version of CMake. Uses the official pre-compiled binaries from the CMake website.",
   "documentationURL": "https://github.com/adamlm/devcontainer-features/tree/main/src/cmake",

--- a/src/cmake/install.sh
+++ b/src/cmake/install.sh
@@ -10,24 +10,40 @@ then
     echo "[CMake Feature] 'wget' not found. Installing through 'apt'"
     apt update
     DEBIAN_FRONTEND=noninteractive apt install --yes --quiet wget
-    rm -rf /var/lib/apt/lists/*
 fi
+
+if ! command -v arch &> /dev/null
+then
+    echo "[CMake Feature] 'arch' not found. Installing through 'apt'"
+    apt update
+    DEBIAN_FRONTEND=noninteractive apt install --yes --quiet coreutils
+fi
+
+if command -v cmake &> /dev/null
+then
+    echo "[CMake Feature] Existing 'cmake' installation found. Uninstalling."
+    DEBIAN_FRONTEND=noninteractive apt remove --yes --quiet cmake
+fi
+
+rm -rf /var/lib/apt/lists/*
 
 echo "[CMake Feature] Downloading CMake binary"
 
+ARCH=$(arch)
+
 cd /tmp
-wget --quiet https://github.com/Kitware/CMake/releases/download/v${VERSION}/cmake-${VERSION}-linux-x86_64.sh
-wget --quiet https://github.com/Kitware/CMake/releases/download/v${VERSION}/cmake-${VERSION}-linux-x86_64.tar.gz
+wget --quiet https://github.com/Kitware/CMake/releases/download/v${VERSION}/cmake-${VERSION}-linux-${ARCH}.sh
+wget --quiet https://github.com/Kitware/CMake/releases/download/v${VERSION}/cmake-${VERSION}-linux-${ARCH}.tar.gz
 
 echo "[CMake Feature] Installing CMake"
 
-chmod u+x cmake-${VERSION}-linux-x86_64.sh
-./cmake-${VERSION}-linux-x86_64.sh --skip-license --include-subdir --prefix=/opt
+chmod u+x cmake-${VERSION}-linux-${ARCH}.sh
+./cmake-${VERSION}-linux-${ARCH}.sh --skip-license --include-subdir --prefix=/opt
 
-rm cmake-${VERSION}-linux-x86_64.sh
-rm cmake-${VERSION}-linux-x86_64.tar.gz
+rm cmake-${VERSION}-linux-${ARCH}.sh
+rm cmake-${VERSION}-linux-${ARCH}.tar.gz
 
-echo 'export PATH=/opt/cmake-'${VERSION}'-linux-x86_64/bin:$PATH' >> /etc/profile.d/cmake_path.sh
+echo 'export PATH=/opt/cmake-'${VERSION}'-linux-'${ARCH}'/bin:$PATH' >> /etc/profile.d/cmake_path.sh
 
 cd -
 


### PR DESCRIPTION
The installation script now detects the system architecture, which gets incorporated into the CMake version that gets downloaded.

Closes #6 